### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ $ composer run-script documentation
 ```
 
 
-
 ## ライセンス - License
 
-MIT License
+Copyright (c)2001-2016 Tomoya Koyanagi, and Pickles 2 Project<br />
+MIT License https://opensource.org/licenses/mit-license.php
 
 
 ## 作者 - Author

--- a/px-files/_sys/php/px.php
+++ b/px-files/_sys/php/px.php
@@ -82,7 +82,7 @@ class px{
 	 * @return string バージョン番号を示す文字列
 	 */
 	public function get_version(){
-		return '2.0.20';
+		return '2.0.21-alpha.1+nb';
 	}
 
 	/**


### PR DESCRIPTION
MIT License は、全文または原文へのリンク を貼ることになっているらしいので、記述修正。
期間は、2001年(Pickles Framework 0.x の開発が始まった年)から開始とした。
著作権者は Pickles 2 Project だが、2001年当時はなかったので Tomoya Koyanagi を併記した。