### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ $ chmod -R 777 ./caches
 ### Pickles Framework 2.0.33 (20??年??月??日)
 
 - `$site()->get_path_param()` で存在しないキーを要求した場合にエラーが起きる問題を修正した。
+- `$px->internal_sub_request()` が、サブリクエストが発行した標準エラー出力を `$px->error()` に転送するようになった。
 - その他、軽微な不具合の修正。
 
 ### Pickles Framework 2.0.32 (2017年5月30日)

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,7 @@
 <phpunit>
 	<testsuites>
 		<testsuite name="default">
+			<file>./tests/mainTest.php</file>
 			<file>./tests/picklesTest.php</file>
 			<file>./tests/headerTest.php</file>
 			<file>./tests/encodingConverterTest.php</file>

--- a/px-files/_sys/php/px.php
+++ b/px-files/_sys/php/px.php
@@ -778,12 +778,14 @@ class px{
 		if(!strlen($request_path)){ $request_path = '/'; }
 		if(is_null($options)){ $options = array(); }
 		$php_command = array();
-		array_push( $php_command, $this->conf()->commands->php );
+		array_push( $php_command, addslashes($this->conf()->commands->php) );
+			// ↑ Windows でこれを `escapeshellarg()` でエスケープすると、なぜかエラーに。
+
 		if( strlen(@$this->conf()->path_phpini) ){
 			$php_command = array_merge(
 				$php_command,
 				array(
-					'-c', @$this->conf()->path_phpini,// ← php.ini のパス
+					'-c', escapeshellarg(@$this->conf()->path_phpini),// ← php.ini のパス
 				)
 			);
 		}
@@ -791,25 +793,25 @@ class px{
 			$php_command = array_merge(
 				$php_command,
 				array(
-					'-d', @$this->req()->get_cli_option( '-d' ),// ← php.ini definition
+					'-d', escapeshellarg(@$this->req()->get_cli_option( '-d' )),// ← php.ini definition
 				)
 			);
 		}
-		array_push($php_command, $_SERVER['SCRIPT_FILENAME']);
+		array_push($php_command, ''.realpath($_SERVER['SCRIPT_FILENAME']).'');
 		if( @$options['output'] == 'json' ){
 			array_push($php_command, '-o');
 			array_push($php_command, 'json');
 		}
 		if( @strlen($options['user_agent']) ){
 			array_push($php_command, '-u');
-			array_push($php_command, $options['user_agent']);
+			array_push($php_command, escapeshellarg($options['user_agent']));
 		}
-		array_push($php_command, $request_path);
+		array_push($php_command, escapeshellarg($request_path));
 
 
 		$cmd = array();
-		foreach( $php_command as $row ){
-			$param = escapeshellarg($row);
+		foreach( $php_command as $param ){
+			// $param = escapeshellarg($param);
 			array_push( $cmd, $param );
 		}
 		$cmd = implode( ' ', $cmd );

--- a/tests/mainTest.php
+++ b/tests/mainTest.php
@@ -35,10 +35,13 @@ class mainTest extends PHPUnit_Framework_TestCase{
 			array(),
 			$vars
 		);
+		$error = $px->get_errors();
 		// var_dump($output);
 		// var_dump($vars);
+		// var_dump($error);
 		$this->assertTrue( is_string($output) );
-		$this->assertTrue( $vars === 0 );
+		$this->assertSame( 0, $vars ); // <- strict equals
+		$this->assertSame( array(), $error );
 
 
 		chdir($cd);

--- a/tests/mainTest.php
+++ b/tests/mainTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * test for pickles2/px-fw-2.x
+ */
+class mainTest extends PHPUnit_Framework_TestCase{
+	private $fs;
+
+	public function setup(){
+		mb_internal_encoding('UTF-8');
+		$this->fs = new tomk79\filesystem();
+		require_once(__DIR__.'/libs/simple_html_dom.php');
+	}
+
+
+	/**
+	 * 普通にインスタンス化して実行してみるテスト
+	 */
+	public function testStandard(){
+		$cd = realpath('.');
+		$SCRIPT_FILENAME = $_SERVER['SCRIPT_FILENAME'];
+		chdir(__DIR__.'/testData/standard/');
+		$_SERVER['SCRIPT_FILENAME'] = __DIR__.'/testData/standard/.px_execute.php';
+
+		$px = new picklesFramework2\px('./px-files/');
+		$toppage_info = $px->site()->get_page_info('');
+		// var_dump($toppage_info);
+		$this->assertEquals( $toppage_info['title'], '<HOME>' );
+		$this->assertEquals( $toppage_info['path'], '/index.html' );
+		$this->assertEquals( $_SERVER['HTTP_USER_AGENT'], '' );
+
+
+		// サブリクエストでキャッシュを消去
+		$output = $px->internal_sub_request(
+			'/index.html?PX=clearcache',
+			array(),
+			$vars
+		);
+		// var_dump($output);
+		// var_dump($vars);
+		$this->assertTrue( is_string($output) );
+		$this->assertTrue( $vars === 0 );
+
+
+		chdir($cd);
+		$_SERVER['SCRIPT_FILENAME'] = $SCRIPT_FILENAME;
+
+		$px->__destruct();// <- required on Windows
+		unset($px);
+	}
+
+}

--- a/tests/picklesTest.php
+++ b/tests/picklesTest.php
@@ -13,36 +13,7 @@ class picklesTest extends PHPUnit_Framework_TestCase{
 
 
 	/**
-	 * 普通にインスタンス化して実行してみるテスト
-	 */
-	public function testStandard(){
-		$cd = realpath('.');
-		chdir(__DIR__.'/testData/standard/');
-
-		$px = new picklesFramework2\px('./px-files/');
-		$toppage_info = $px->site()->get_page_info('');
-		// var_dump($toppage_info);
-		$this->assertEquals( $toppage_info['title'], '<HOME>' );
-		$this->assertEquals( $toppage_info['path'], '/index.html' );
-		$this->assertEquals( $_SERVER['HTTP_USER_AGENT'], '' );
-
-		chdir($cd);
-		$px->__destruct();// <- required on Windows
-		unset($px);
-
-		// 後始末
-		$output = $this->px_execute( '/standard/.px_execute.php', '/?PX=clearcache' );
-		clearstatcache();
-		// var_dump($output);
-		$this->assertTrue( $this->common_error( $output ) );
-		$this->assertTrue( !is_dir( __DIR__.'/testData/standard/caches/p/' ) );
-		$this->assertTrue( !is_dir( __DIR__.'/testData/standard/px-files/_sys/ram/caches/sitemaps/' ) );
-
-	}
-
-	/**
 	 * 普通にコマンドラインから実行してみるテスト
-	 * @depends testStandard
 	 */
 	public function testCLIStandard(){
 		$output = $this->px_execute( '/standard/.px_execute.php', '/' );


### PR DESCRIPTION
- `$px->internal_sub_request()` が、サブリクエストが発行した標準エラー出力を `$px->error()` に転送するようになった。